### PR TITLE
feat: add command for publishing assets

### DIFF
--- a/src/ApiConsoleModuleServiceProvider.php
+++ b/src/ApiConsoleModuleServiceProvider.php
@@ -9,6 +9,7 @@ use Filament\PluginServiceProvider;
 use HexDigital\ApiConsoleModule\Actions\RefactorFileAction;
 use HexDigital\ApiConsoleModule\Commands\MakeUserCommand;
 use HexDigital\ApiConsoleModule\Commands\Aliases\MakeUserCommand as MakeUserCommandAlias;
+use HexDigital\ApiConsoleModule\Commands\PublishCommand;
 use HexDigital\ApiConsoleModule\Models\Admin;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
@@ -36,6 +37,7 @@ final class ApiConsoleModuleServiceProvider extends PluginServiceProvider
             ->hasCommands(commandClassNames: [
                 MakeUserCommand::class,
                 MakeUserCommandAlias::class,
+                PublishCommand::class,
             ]);
     }
 

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HexDigital\ApiConsoleModule\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use SplFileInfo;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'api-console-module:publish')]
+final class PublishCommand extends Command
+{
+    protected $signature = 'api-console-module:publish {--force : Overwrite any existing files}';
+
+    protected $description = 'Publish all of the console module resources';
+
+    public function handle(Filesystem $files): void
+    {
+        $this->call(
+            command: 'vendor:publish',
+            arguments: [
+                '--tag' => 'api-console-module-config',
+                '--force' => $this->option('force'),
+            ],
+        );
+
+        // Delete any legacy CSS files (due to asset versioning)
+        if ($files->isDirectory(directory: $directory = public_path(path: 'vendor/api-console-module/assets'))) {
+            collect(value: $files->allFiles(directory: $directory))
+                ->reject(fn (SplFileInfo $file) => ! Str::endsWith($file->getFilename(), '.css'))
+                ->each(fn (SplFileInfo $file) => $files->delete(paths: [
+                    $file->getPathname(),
+                ]));
+        }
+
+        $this->call(
+            command: 'vendor:publish',
+            arguments: [
+                '--tag' => 'api-console-module-assets',
+                '--force' => true,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds a command for publishing assets `api-console-module:publish`. This will allow us to register the command as a `post-update-cmd` composer script so that assets are always kept up to date when updating the package.