### PR TITLE
chore: remove final classes

### DIFF
--- a/src/Actions/RefactorFileAction.php
+++ b/src/Actions/RefactorFileAction.php
@@ -7,7 +7,7 @@ namespace HexDigital\AdminModule\Actions;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
-final class RefactorFileAction
+class RefactorFileAction
 {
     public function __construct(
         protected Filesystem $files,

--- a/src/AdminModuleServiceProvider.php
+++ b/src/AdminModuleServiceProvider.php
@@ -20,7 +20,7 @@ use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\Permission\Models\Role;
 
-final class AdminModuleServiceProvider extends PluginServiceProvider
+class AdminModuleServiceProvider extends PluginServiceProvider
 {
     public function configurePackage(Package $package): void
     {

--- a/src/Commands/Aliases/MakeUserCommand.php
+++ b/src/Commands/Aliases/MakeUserCommand.php
@@ -6,7 +6,7 @@ namespace HexDigital\AdminModule\Commands\Aliases;
 
 use HexDigital\AdminModule\Commands\MakeUserCommand as Command;
 
-final class MakeUserCommand extends Command
+class MakeUserCommand extends Command
 {
     protected $hidden = true;
 

--- a/src/Commands/PermissionSyncCommand.php
+++ b/src/Commands/PermissionSyncCommand.php
@@ -9,7 +9,7 @@ use Spatie\Permission\Models\Permission;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'permission:sync')]
-final class PermissionSyncCommand extends Command
+class PermissionSyncCommand extends Command
 {
     protected $signature = 'permission:sync';
 

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -11,7 +11,7 @@ use SplFileInfo;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'admin-module:publish')]
-final class PublishCommand extends Command
+class PublishCommand extends Command
 {
     protected $signature = 'admin-module:publish {--force : Overwrite any existing files}';
 

--- a/src/Filament/Resources/AdminResource/RelationManagers/RolesRelationManager.php
+++ b/src/Filament/Resources/AdminResource/RelationManagers/RolesRelationManager.php
@@ -16,7 +16,7 @@ use HexDigital\AdminModule\Models\Admin;
 use Illuminate\Contracts\Auth\Guard;
 use Spatie\Permission\Models\Role;
 
-final class RolesRelationManager extends RelationManager
+class RolesRelationManager extends RelationManager
 {
     protected static string $relationship = 'roles';
 

--- a/src/Models/Admin.php
+++ b/src/Models/Admin.php
@@ -16,7 +16,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property string $last_name
  * @property string $email
  */
-final class Admin extends Authenticatable
+class Admin extends Authenticatable
 {
     use HasRoles;
     use Notifiable;


### PR DESCRIPTION
This PR removes the `final` keyword from all classes. By having `final`, it makes it very difficult to override and extend a class within the application.